### PR TITLE
[문서 수정] docs/the-gist-of-mobx

### DIFF
--- a/docs/the-gist-of-mobx.md
+++ b/docs/the-gist-of-mobx.md
@@ -158,7 +158,7 @@ render(<TodoListView todoList={store} />, document.getElementById("root"))
 ```
 
 `observer`는 리액트 컴포넌트를 렌더링하는 데이터의 derivation으로 변환합니다.
-MobX를 사용하면 smart 컴포넌트나 dump 컴포넌트의 구분이 없습니다.
+MobX를 사용하면 smart 컴포넌트나 dumb 컴포넌트의 구분이 없습니다.
 모든 컴포넌트는 smart하게 렌더링 되지만, dumb하게 정의됩니다. MobX에서는 필요할 때마다 컴포넌트가 다시 렌더링 되며, 그 이상은 렌더링 되지 않습니다.
 
 따라서 위 예제의 `onClick` 핸들러는 `toggle` action을 사용할 때 적절한 `TodoView` 컴포넌트를 강제로 다시 렌더링하지만, `TodoListView` 컴포넌트는 완료되지 않은 작업의 수(unfinishedTodoCount)가 변경된 경우에만 다시 렌더링 됩니다.


### PR DESCRIPTION
오타 수정: dump => dumb
- [Original Docs](https://mobx.js.org/the-gist-of-mobx.html#33-reactive-react-components): "When using MobX there are no smart or dumb components."

<!--
    Thanks for taking the effort to create a PR! 🙌

    👋 Are you making a change to documentation only? Delete the rest of the template and go ahead.

    👋 If you are creating an extensive PR, you might want to open an issue with your idea first in case there is a chance for rejecting it.

    👋 If you intend to work on PR over several days, please, create [draft pull requests](https://github.blog/2019-02-14-introducing-draft-pull-requests/) instead.

    👇 Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

### Code change checklist

-   [ ] Added/updated unit tests
-   [ ] Updated `/docs`. For new functionality, at least `API.md` should be updated
-   [ ] Verified that there is no significant performance drop (`npm run perf`)

<!--
    Feel free to ask help with any of these boxes!
-->
